### PR TITLE
cmd/unity: fix Gerrit revision resolver test

### DIFF
--- a/cmd/unity/cmd/testdata/scripts/test_project_gerrit_ref_resolver.txt
+++ b/cmd/unity/cmd/testdata/scripts/test_project_gerrit_ref_resolver.txt
@@ -8,9 +8,9 @@ git add -A
 git commit -m 'Initial commit'
 
 # Test - ref corresponds to the same commit as v0.3.0-beta.5
-unity test refs/changes/07/8707/3
+unity test refs/changes/69/520169/1
 ! stdout .+
-stderr 'ok.*mod\.com.*refs/changes/07/8707/3'
+stderr 'ok.*mod\.com.*refs/changes/69/520169/1'
 
 -- .unquote --
 cue.mod/tests/basic.txt


### PR DESCRIPTION
With the switch to GerritHub, the Gerrit resolver resolves relative to a
different URL (GerritHub instead of GoogleSource). Hence the hard-coded
reference that we have as part of our test now fails when tested against
a commit of the CUE repo after (and including) 06484a39.

Fix this by providing a reference for a change in the GerritHub setup.

Signed-off-by: Paul Jolly <paul@myitcv.io>